### PR TITLE
Improve numerical stability of projection

### DIFF
--- a/lib/shaders/backgroundVert.glsl
+++ b/lib/shaders/backgroundVert.glsl
@@ -19,7 +19,7 @@ void main() {
     vec3 minRange = min(bounds[0], bounds[1]);
     vec3 maxRange = max(bounds[0], bounds[1]);
     vec3 nPosition = mix(minRange, maxRange, 0.5 * (position + 1.0));
-    gl_Position = projection * view * model * vec4(nPosition, 1.0);
+    gl_Position = projection * (view * (model * vec4(nPosition, 1.0)));
   } else {
     gl_Position = vec4(0,0,0,0);
   }

--- a/lib/shaders/lineVert.glsl
+++ b/lib/shaders/lineVert.glsl
@@ -8,7 +8,7 @@ uniform float lineWidth;
 uniform vec2 screenShape;
 
 vec3 project(vec3 p) {
-  vec4 pp = projection * view * model * vec4(p, 1.0);
+  vec4 pp = projection * (view * (model * vec4(p, 1.0)));
   return pp.xyz / max(pp.w, 0.0001);
 }
 

--- a/lib/shaders/textVert.glsl
+++ b/lib/shaders/textVert.glsl
@@ -8,7 +8,7 @@ uniform float scale, angle, pixelScale;
 uniform vec2 resolution;
 
 vec3 project(vec3 p) {
-  vec4 pp = projection * view * model * vec4(p, 1.0);
+  vec4 pp = projection * (view * (model * vec4(p, 1.0)));
   return pp.xyz / max(pp.w, 0.0001);
 }
 


### PR DESCRIPTION
When the position vector has large values that are cancelled out by large values in the model matrix, it is more numerically stable to first multiply the position by the model matrix instead of multiplying the matrices together first.